### PR TITLE
Fixed Bottom Scrollbar Display

### DIFF
--- a/style.css
+++ b/style.css
@@ -8,6 +8,9 @@
 
 body{
     transition: background-color ease-out .5s;
+    
+    /*I set the overflow-x variable to hidden to make only the y axis scrollbar visible. Phillip Andrews*/
+    overflow-x: hidden;
 }
 
 *::selection{


### PR DESCRIPTION
I changed the overflow in the body in the styles.css file to make only the vertical scrollbar visible.